### PR TITLE
chrome.bluetooth: respect the characteristic's writeWithoutResponse property

### DIFF
--- a/chrome-cordova/plugins/chrome.bluetooth/src/ios/ChromeBluetooth.m
+++ b/chrome-cordova/plugins/chrome.bluetooth/src/ios/ChromeBluetooth.m
@@ -382,7 +382,11 @@
 {
     CBCharacteristic* characteristic = _knownCharacteristics[characteristicId];
     if (characteristic) {
-        [_peripheral writeValue:value forCharacteristic:characteristic type:CBCharacteristicWriteWithResponse];
+        CBCharacteristicWriteType type = CBCharacteristicWriteWithResponse;
+        if (characteristic.properties & CBCharacteristicPropertyWriteWithoutResponse)
+            type = CBCharacteristicWriteWithoutResponse;
+
+        [_peripheral writeValue:value forCharacteristic:characteristic type:type];
         return YES;
     }
     return NO;


### PR DESCRIPTION
Without this, writes to a device I'm testing fail.  Responses are provided
through characteristic changed notifications.