### PR TITLE
Legacy whitelist plugin should be used

### DIFF
--- a/cca-manifest-logic/src/plugin-maps.js
+++ b/cca-manifest-logic/src/plugin-maps.js
@@ -11,7 +11,7 @@ var DEFAULT_PLUGINS = [
     'cordova-plugin-inappbrowser',
     'cordova-plugin-network-information',
     'cordova-plugin-statusbar',
-    'cordova-plugin-whitelist',
+    'cordova-plugin-whitelist@1.0.0',
     'cordova-plugin-chrome-apps-common',
     'cordova-plugin-chrome-apps-runtime',
     'cordova-plugin-chrome-apps-storage',


### PR DESCRIPTION
Cordova updated plugin-whitelist rendering
it incompatible with cordova-ios-3.8.0, the
legacy version should be used instead

http://cordova.apache.org/announcements/2015/04/21/plugins-release-and-move-to-npm.html
"We recently released cordova-plugin-whitelist and cordova-plugin-legacy-whitelist. We have revamped how whitelisting works starting with cordova-android@4.0.0."
